### PR TITLE
Add clarifying comments to executor safety handling

### DIFF
--- a/control/executor.py
+++ b/control/executor.py
@@ -44,6 +44,8 @@ async def _run_steps(
 ) -> int:
     """Execute all steps and return the count of executed items."""
 
+    # Keep track of how many steps have successfully passed validation and
+    # been either simulated or sent to the hardware interface.
     count = 0
     for step in steps:
         _validate_step(step)
@@ -76,6 +78,8 @@ async def execute_move(
         :class:`SimulatedHardware` instance is created lazily if not provided.
     """
 
+    # Default to a simulated hardware interface so that call sites do not need
+    # to provide one explicitly during tests or local development runs.
     if hardware is None:
         hardware = SimulatedHardware()
 


### PR DESCRIPTION
## Summary
- add inline comments explaining how the executor counts validated steps
- document the rationale for using the simulated hardware by default

## Testing
- pytest

#CU-86dy7wakk[complete]

------
https://chatgpt.com/codex/tasks/task_e_690284e3a45c832ca8e2a727f149c50d